### PR TITLE
Add instanceGroup.get permission to WC and MC role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
-- Add script to configure apps using workload identity
 
+- Add script to configure apps using workload identity
+- Add `compute.instanceGroups.get` to WC and MC custom role
 
 [Unreleased]: https://github.com/giantswarm/workload-identity-gcp-utils/tree/master

--- a/scripts/assets/cluster_control_plane_node_custom_role.yaml
+++ b/scripts/assets/cluster_control_plane_node_custom_role.yaml
@@ -7,6 +7,7 @@ includedPermissions:
 - compute.disks.get
 - compute.disks.list
 - compute.disks.use
+- compute.instanceGroups.get
 - compute.instances.attachDisk
 - compute.instances.detachDisk
 - compute.instances.get

--- a/scripts/assets/cluster_worker_node_custom_role.yaml
+++ b/scripts/assets/cluster_worker_node_custom_role.yaml
@@ -7,6 +7,7 @@ includedPermissions:
 - compute.disks.get
 - compute.disks.list
 - compute.disks.use
+- compute.instanceGroups.get
 - compute.instances.attachDisk
 - compute.instances.detachDisk
 - compute.instances.get


### PR DESCRIPTION
### What does this PR do?

This is required to create internal loadbalancers

### What is the effect of this change to users?

It allows users to configure nginx ingress controller with an internal loadbalancer for private ingress

### What is needed from the reviewers?

Check if in conflict with general security concerns 

### Do the docs need to be updated?
No

### Should this change be mentioned in the release notes?
Maybe

- [x] CHANGELOG.md has been updated (if it exists)
